### PR TITLE
chore(usernames): Adding request editors to targets for username construction

### DIFF
--- a/username/request.go
+++ b/username/request.go
@@ -2,7 +2,6 @@ package username
 
 import (
 	"net/http"
-	"net/url"
 )
 
 // isStatusOK returns true if the response status code accepts 2xx codes as successful.
@@ -11,6 +10,6 @@ func isStatusOK(resp *http.Response) bool {
 }
 
 // appendUsernameToURL appends the given username to the target URL's path.
-func appendUsernameToURL(targetURL *url.URL, username string) *url.URL {
-	targetURL.JoinPath(username)
+func appendUsernameToURL(req *http.Request, username string) {
+	req.URL = req.URL.JoinPath(req.URL.Path, username)
 }

--- a/username/request.go
+++ b/username/request.go
@@ -1,0 +1,16 @@
+package username
+
+import (
+	"net/http"
+	"net/url"
+)
+
+// isStatusOK returns true if the response status code accepts 2xx codes as successful.
+func isStatusOK(resp *http.Response) bool {
+	return resp.StatusCode >= 200 && resp.StatusCode < 300
+}
+
+// appendUsernameToURL appends the given username to the target URL's path.
+func appendUsernameToURL(targetURL *url.URL, username string) *url.URL {
+	targetURL.JoinPath(username)
+}

--- a/username/targets.go
+++ b/username/targets.go
@@ -9,11 +9,14 @@ import (
 	pkgslices "github.com/jacobbrewer1/web/slices"
 )
 
+type requestEditorFunc = func(*http.Request, string)
+
 type target struct {
 	url                 *url.URL
 	name                string
 	isRequestSuccessful func(*http.Response) bool
 	urlBuilder          func(*url.URL, string) *url.URL
+	requestEditor       []requestEditorFunc
 }
 
 var allTargets = map[string]*target{
@@ -21,101 +24,127 @@ var allTargets = map[string]*target{
 		name:                strings.ToTitle("facebook"),
 		url:                 parseTargetURL("https://www.facebook.com/"),
 		isRequestSuccessful: isStatusOK,
+		requestEditor:       []requestEditorFunc{appendUsernameToURL},
 	},
 	"twitter": {
 		name:                strings.ToTitle("twitter"),
 		url:                 parseTargetURL("https://x.com/"),
 		isRequestSuccessful: isStatusOK,
+		requestEditor:       []requestEditorFunc{appendUsernameToURL},
 	},
 	"instagram": {
 		name:                strings.ToTitle("instagram"),
 		url:                 parseTargetURL("https://www.instagram.com/"),
 		isRequestSuccessful: isStatusOK,
+		requestEditor:       []requestEditorFunc{appendUsernameToURL},
 	},
 	"linkedin": {
 		name:                strings.ToTitle("linkedin"),
 		url:                 parseTargetURL("https://www.linkedin.com/in/"),
 		isRequestSuccessful: isStatusOK,
+		requestEditor:       []requestEditorFunc{appendUsernameToURL},
 	},
 	"github": {
 		name:                strings.ToTitle("github"),
 		url:                 parseTargetURL("https://www.github.com/"),
 		isRequestSuccessful: isStatusOK,
+		requestEditor:       []requestEditorFunc{appendUsernameToURL},
 	},
 	"pinterest": {
 		name:                strings.ToTitle("pinterest"),
 		url:                 parseTargetURL("https://www.pinterest.com/"),
 		isRequestSuccessful: isStatusOK,
+		requestEditor:       []requestEditorFunc{appendUsernameToURL},
 	},
 	"tumblr": {
 		name:                strings.ToTitle("tumblr"),
 		url:                 parseTargetURL("https://www.tumblr.com/"),
 		isRequestSuccessful: isStatusOK,
+		requestEditor:       []requestEditorFunc{appendUsernameToURL},
 	},
 	"youtube": {
 		name:                strings.ToTitle("youtube"),
 		url:                 parseTargetURL("https://www.youtube.com/"),
 		isRequestSuccessful: isStatusOK,
+		requestEditor:       []requestEditorFunc{appendUsernameToURL},
 	},
 	"soundcloud": {
 		name:                strings.ToTitle("soundcloud"),
 		url:                 parseTargetURL("https://soundcloud.com/"),
 		isRequestSuccessful: isStatusOK,
+		requestEditor:       []requestEditorFunc{appendUsernameToURL},
 	},
 	"snapchat": {
 		name:                strings.ToTitle("snapchat"),
 		url:                 parseTargetURL("https://www.snapchat.com/add/"),
 		isRequestSuccessful: isStatusOK,
+		requestEditor:       []requestEditorFunc{appendUsernameToURL},
 	},
 	"tiktok": {
 		name:                strings.ToTitle("tiktok"),
-		url:                 parseTargetURL("https://www.tiktok.com/@"),
+		url:                 parseTargetURL("https://www.tiktok.com/"),
 		isRequestSuccessful: isStatusOK,
+		requestEditor: []requestEditorFunc{func(req *http.Request, username string) {
+			appendUsernameToURL(req, "@"+username)
+		}},
 	},
 	"behance": {
 		name:                strings.ToTitle("behance"),
 		url:                 parseTargetURL("https://www.behance.net/"),
 		isRequestSuccessful: isStatusOK,
+		requestEditor:       []requestEditorFunc{appendUsernameToURL},
 	},
 	"medium": {
 		name:                strings.ToTitle("medium"),
-		url:                 parseTargetURL("https://www.medium.com/@"),
+		url:                 parseTargetURL("https://www.medium.com/"),
 		isRequestSuccessful: isStatusOK,
+		requestEditor: []requestEditorFunc{func(req *http.Request, username string) {
+			appendUsernameToURL(req, "@"+username)
+		}},
 	},
 	"quora": {
 		name:                strings.ToTitle("quora"),
 		url:                 parseTargetURL("https://www.quora.com/profile/"),
 		isRequestSuccessful: isStatusOK,
+		requestEditor:       []requestEditorFunc{appendUsernameToURL},
 	},
 	"flickr": {
 		name:                strings.ToTitle("flickr"),
 		url:                 parseTargetURL("https://www.flickr.com/people/"),
 		isRequestSuccessful: isStatusOK,
+		requestEditor:       []requestEditorFunc{appendUsernameToURL},
 	},
 	"twitch": {
 		name:                strings.ToTitle("twitch"),
 		url:                 parseTargetURL("https://www.twitch.tv/"),
 		isRequestSuccessful: isStatusOK,
+		requestEditor:       []requestEditorFunc{appendUsernameToURL},
 	},
 	"dribbble": {
 		name:                strings.ToTitle("dribbble"),
 		url:                 parseTargetURL("https://www.dribbble.com/"),
 		isRequestSuccessful: isStatusOK,
+		requestEditor:       []requestEditorFunc{appendUsernameToURL},
 	},
 	"ello": {
 		name:                strings.ToTitle("ello"),
 		url:                 parseTargetURL("https://www.ello.co/"),
 		isRequestSuccessful: isStatusOK,
+		requestEditor:       []requestEditorFunc{appendUsernameToURL},
 	},
 	"product_hunt": {
 		name:                strings.ToTitle("Product Hunt"),
-		url:                 parseTargetURL("https://www.producthunt.com/@"),
+		url:                 parseTargetURL("https://www.producthunt.com/"),
 		isRequestSuccessful: isStatusOK,
+		requestEditor: []requestEditorFunc{func(req *http.Request, username string) {
+			appendUsernameToURL(req, "@"+username)
+		}},
 	},
 	"telegram": {
 		name:                strings.ToTitle("telegram"),
 		url:                 parseTargetURL("https://www.telegram.me/"),
 		isRequestSuccessful: isStatusOK,
+		requestEditor:       []requestEditorFunc{appendUsernameToURL},
 	},
 }
 

--- a/username/targets.go
+++ b/username/targets.go
@@ -15,7 +15,6 @@ type target struct {
 	url                 *url.URL
 	name                string
 	isRequestSuccessful func(*http.Response) bool
-	urlBuilder          func(*url.URL, string) *url.URL
 	requestEditor       []requestEditorFunc
 }
 

--- a/username/targets.go
+++ b/username/targets.go
@@ -9,14 +9,11 @@ import (
 	pkgslices "github.com/jacobbrewer1/web/slices"
 )
 
-func isStatusOK(resp *http.Response) bool {
-	return resp.StatusCode >= 200 && resp.StatusCode < 300
-}
-
 type target struct {
 	url                 *url.URL
 	name                string
 	isRequestSuccessful func(*http.Response) bool
+	urlBuilder          func(*url.URL, string) *url.URL
 }
 
 var allTargets = map[string]*target{

--- a/username/track.go
+++ b/username/track.go
@@ -71,11 +71,13 @@ func TrackUsername(ctx context.Context, username string, searchTargets []string)
 
 // track checks if a username exists on a given target platform.
 func track(ctx context.Context, username string, target *target) (bool, error) {
-	targetURL := target.url.JoinPath(username)
-
-	req, err := http.NewRequestWithContext(ctx, "GET", targetURL.String(), http.NoBody)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, target.url.String(), http.NoBody)
 	if err != nil {
 		return false, fmt.Errorf("failed to create request for %s: %w", target.name, err)
+	}
+
+	for _, editor := range target.requestEditor {
+		editor(req, username)
 	}
 
 	client := &http.Client{}


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->

This pull request refactors how username URLs are constructed and requested for different social media targets. The main change is the introduction of a flexible request editing mechanism, allowing each target to customize how usernames are appended to URLs. This improves maintainability and makes it easier to handle platforms with unique URL formats.

### Refactoring and extensibility improvements

* Added `requestEditor` field to the `target` struct in `username/targets.go`, allowing each target to specify one or more functions to modify the request before sending. This replaces the previous hardcoded approach and enables more flexible username handling per target.
* Updated the `track` function in `username/track.go` to use the new `requestEditor` mechanism, applying all relevant editors to the request before sending.

### Platform-specific URL handling

* For platforms like TikTok, Medium, and Product Hunt, replaced direct URL path concatenation with a custom editor that prepends an "@" to the username, ensuring correct URL formatting for those sites.

### Utility and code organization

* Moved the `isStatusOK` function and introduced the `appendUsernameToURL` utility in a new file, `username/request.go`, improving code organization and reuse.
* Updated target URL initialization for several platforms to remove hardcoded "@" in the base URL, delegating this logic to the new request editors for better consistency and maintainability.