### PR TITLE
fix(username): rm bad commit test error

### DIFF
--- a/username/track.go
+++ b/username/track.go
@@ -2,7 +2,6 @@ package username
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -75,7 +74,7 @@ func TrackUsername(ctx context.Context, username string, searchTargets []string)
 	}
 
 	displayResultTable(username, resultMap)
-	return errors.New("test")
+	return nil
 }
 
 // track checks if a username exists on a given target platform.


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->

This pull request makes a minor fix to the `TrackUsername` function in the `username/track.go` file. The function now correctly returns `nil` instead of an error after displaying the result table.

* Changed the return value of `TrackUsername` from `errors.New("test")` to `nil`, indicating successful completion.
* Removed the unnecessary import of the `errors` package from `username/track.go`.